### PR TITLE
codecov is no longer a valid pypi package

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Tests
         run: |
           pip3 install -r requirements.txt -r tests/requirements.txt && \
-          pip3 install codecov && \
           PYTHONPATH=. python3 -m birdseye.baseline --help \
           PYTHONPATH=. python3 -m birdseye.dqn --help && \
           PYTHONPATH=. python3 -m birdseye.mcts --help && \


### PR DESCRIPTION
remove call to install from workflows as it causes workflows to fail.